### PR TITLE
Logging interference

### DIFF
--- a/paypal/__init__.py
+++ b/paypal/__init__.py
@@ -7,6 +7,5 @@ from paypal.settings import PayPalConfig
 from paypal.exceptions import PayPalError, PayPalConfigError, PayPalAPIResponseError
 #noinspection PyUnresolvedReferences
 import paypal.countries
-import logging
 
 VERSION = '1.2.0'


### PR DESCRIPTION
Hi, 

Lately we realized that after paypal library is imported, our root logger gets configured and this is not a behavior we wan't. Other people might be feeling the same way. 

Configuring logging in the library is a discouraged behavior, please observe at the notes of the following link:

http://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
