### PR TITLE
Call paypal using a POST request.

### DIFF
--- a/paypal/interface.py
+++ b/paypal/interface.py
@@ -116,12 +116,12 @@ class PayPalInterface(object):
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug('PayPal NVP Query Key/Vals:\n%s' % pformat(url_values))
 
-        req = requests.get(
+        req = requests.post(
             self.config.API_ENDPOINT,
-            params=url_values,
+            data=url_values,
             timeout=self.config.HTTP_TIMEOUT,
             verify=self.config.API_CA_CERTS,
-        )
+            )
 
         # Call paypal API
         response = PayPalResponse(req.text, self.config)


### PR DESCRIPTION
When the URL is too long (~4500 characters), Paypal is rejecting the call with :
TIMESTAMP=2013%2d07%2d01T06%3a45%3a59Z&CORRELATIONID=573b84f5c4852&ACK=Failure&L_ERRORCODE0=10001&L_SHORTMESSAGE0=Internal%20Error&L_LONGMESSAGE0=Timeout%20processing%20request

Using post instead of get is fixing the issue.
