### PR TITLE
Implements items method on PayPalResponse

### DIFF
--- a/paypal/response.py
+++ b/paypal/response.py
@@ -97,6 +97,12 @@ class PayPalResponse(object):
         return value
         
     def items(self):
+        items_list = []
+        for key in self.raw.keys():
+            items_list.append((key, self.__getitem__(key))
+        return items_list
+        
+    def iteritems(self):
         for key in self.raw.keys():
             yield (key, self.__getitem__(key))
 


### PR DESCRIPTION
This request implements the items method on PayPalResponse so it can be used more like a dictionary in cases like a for statement for example.
