### PR TITLE
add /cgi-bin/ to base urls

### DIFF
--- a/paypal/settings.py
+++ b/paypal/settings.py
@@ -43,8 +43,8 @@ class PayPalConfig(object):
     }
 
     _PAYPAL_URL_BASE = {
-        'SANDBOX': 'https://www.sandbox.paypal.com/webscr',
-        'PRODUCTION': 'https://www.paypal.com/webscr',
+        'SANDBOX': 'https://www.sandbox.paypal.com/cgi-bin/webscr',
+        'PRODUCTION': 'https://www.paypal.com/cgi-bin/webscr',
     }
 
     API_VERSION = '98.0'


### PR DESCRIPTION
When using the sandbox and express checkout the PayPal page often is unstyled. This seems to be the case quite frequently:
- http://stackoverflow.com/questions/24326407/paypal-payment-page-layout-broken-in-webview-android-maybe-css-not-loaded-correc
- https://www.paypal-community.com/t5/About-Payments/paypal-Android-webview-layout-issue-on-payment-page/td-p/807164
- http://stackoverflow.com/questions/23405919/paypal-payment-page-layout-broken-in-webview-android

PayPal's support staff mentioned that `/cgi-bin/` should be included in the path fo the redirect url. Lastly, PayPal's [documentation](https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECGettingStarted/) always includes `/cgi-bin/` in the redirect url.
